### PR TITLE
Add GitHub boilerplate and CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+**Context:**
+
+**Description of the Change:**
+
+**Benefits:**
+
+**Possible Drawbacks:**
+
+**Related GitHub Issues:**

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,26 @@
+name: Formatting check
+on:
+- pull_request
+
+jobs:
+  black:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: pip install black
+
+      - uses: actions/checkout@v2
+
+      - name: Run Black
+        run: black -l 100 qdata/ --check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,42 @@
+name: Tests
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token: ${{ github.token }}
+
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Build wheel
+        run: |
+          python setup.py bdist_wheel
+
+      - name: Install wheel
+        run: |
+          python -m pip install --upgrade pip
+          pip install dist/qdata*
+
+      - name: Install test dependencies
+        run: |
+          pip install wheel pytest pytest-cov pytest-mock --upgrade
+
+      - name: Run tests
+        run: python -m pytest tests --cov=qdata --cov-report=term-missing --tb=native


### PR DESCRIPTION
**Changes:**

* Adds a pull request template (a simple one, just to make it easy to fill out and remember to provide all details)

* Adds a black formatting check

* Adds testing, for Python 3.6, 3.7, 3.8. Coverage is displayed in the action log, after the tests pass. Note: this CI will currently fail, however the repo settings currently do not require CI to pass for PRs to be merged.

**Todo in a future PR:**

* Add documentation check (requires documentation to be added first 😆)

* Extend the test action to fail if coverage reduces.

* Add linting