### PR TITLE
Linting and bug fixing

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ on:
 - pull_request
 
 jobs:
-  black:
+  pylint:
     runs-on: ubuntu-latest
 
     steps:
@@ -17,10 +17,12 @@ jobs:
         with:
           python-version: 3.8
 
-      - name: Install dependencies
-        run: pip install pylint
-
       - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          pip install pylint
+          pip install -e .
 
       - name: Run pylint
         run: pylint qdata --disable=fixme

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,26 @@
+name: Linting check
+on:
+- pull_request
+
+jobs:
+  black:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: pip install pylint
+
+      - uses: actions/checkout@v2
+
+      - name: Run pylint
+        run: pylint qdata --disable=fixme

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,31 @@
+[MASTER]
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+[TYPECHECK]
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# List of classes names for which member attributes should not be checked
+# (useful for classes with attributes dynamically set). This supports can work
+# with qualified names.
+ignored-classes=
+
+[MESSAGES CONTROL]
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once).
+disable=line-too-long,invalid-name,too-many-lines,redefined-builtin,too-many-locals,duplicate-code

--- a/example.py
+++ b/example.py
@@ -1,4 +1,4 @@
 import qdata
 
-res = qdata.load("examples/example_data/molecular_hamiltonians.qasm")
-print(res)
+res = qdata.load("examples/example_data/operator_circuit.qasm")
+print(res.serialize(inline=True))

--- a/qdata/__init__.py
+++ b/qdata/__init__.py
@@ -29,8 +29,8 @@ def load(f):
             fid = open(filename, "r")
             own_file = True
 
-    except TypeError:
-        raise ValueError("file must be a string, pathlib.Path, or file-like object")
+    except TypeError as e:
+        raise ValueError("file must be a string, pathlib.Path, or file-like object") from e
 
     try:
         string = fid.read()

--- a/qdata/__init__.py
+++ b/qdata/__init__.py
@@ -54,10 +54,10 @@ def loads(string):
     """
     tree = qasm_parser.parse(string)
     tree = QASMToIRTransformer().transform(tree)
-    return tree.serialize()
+    return tree
 
 
-def dump(prog, f):
+def dump(prog, f, inline=False):
     """Serialize an operator QASM program to a `.write()`-supporting file-like object.
 
     Args:
@@ -65,8 +65,11 @@ def dump(prog, f):
         f (Union[file, str, pathlib.Path]): File or filename to which
             the data is saved. If file is a string or Path, a value with the
             .qasm extension is expected.
+        inline (bool): Whether the files listed via the ``include``
+            keyword should be inserted, inline, into the serialized program.
+
     """
-    text = dumps(prog)
+    text = dumps(prog, inline=inline)
 
     if hasattr(f, "read"):
         # argument file is a file-object
@@ -94,13 +97,15 @@ def dump(prog, f):
     f.write(text)
 
 
-def dumps(prog):
+def dumps(prog, inline=False):
     """Serialize an operator QASM program to a string.
 
     Args:
         prog (.QasmProgram): a :class:`~.QasmProgram` object
+        inline (bool): Whether the files listed via the ``include``
+            keyword should be inserted, inline, into the serialized program.
 
     Returns:
         str: the serialized operator QASM program
     """
-    return prog.serialize()
+    return prog.serialize(inline=inline)

--- a/qdata/_version.py
+++ b/qdata/_version.py
@@ -1,1 +1,3 @@
+"""The current qdata version number. Uses semantic versioning (https://semver.org)"""
+
 __version__ = "0.1.0"

--- a/qdata/ir.py
+++ b/qdata/ir.py
@@ -335,7 +335,7 @@ class Declaration:
         self.goplist = []
 
     def declaration_str(self):
-        """The serialized declaration definition. Note that this only includes
+        """The serialized declaration. Note that this only includes
         the name of the declaration and the declaration keyword arguments; for the
         full serialization (including constituent operators) please see ``__repr__``.
         """

--- a/qdata/ir.py
+++ b/qdata/ir.py
@@ -123,22 +123,22 @@ def format_wires(wire_id_list):
 class ArithmeticOperation:
     """Lightweight class for representing arithmetic operations appearing within the grammar."""
 
-    def __new__(cls, func, *exps):  # pylint:disable=unused-argument
-        if len(exps) == 1:
+    def __new__(cls, func, *args):  # pylint:disable=unused-argument
+        if len(args) == 1:
             return super().__new__(UnaryOperation)
 
-        if len(exps) == 2:
+        if len(args) == 2:
             return super().__new__(BinaryOperation)
 
         return super().__new__(cls)
 
-    def __init__(self, func, *exps):
+    def __init__(self, func, *args):
         self.func = func
-        self.args = exps
-        self.tuple = (func, *exps)
+        self.args = args
+        self.tuple = (func, *args)
 
     def __repr__(self):
-        return "ArithmeticOp(func={}, exps={})".format(self.func, self.args)
+        return "ArithmeticOp(func={}, args={})".format(self.func, self.args)
 
     def __add__(self, other):
         return BinaryOperation("add", self, other)

--- a/qdata/ir.py
+++ b/qdata/ir.py
@@ -257,12 +257,12 @@ class TensorOp:
 
     @property
     def params(self):
-        """A flat list containing all the parameters of constituent operators"""
+        """A flat list containing all the parameters of constituent operators."""
         return self._params
 
     @property
     def wires(self):
-        """A flat list containing the wires of all constituent operators"""
+        """A flat list containing the wires of all constituent operators."""
         return self._wires
 
     def __repr__(self):

--- a/qdata/parser.py
+++ b/qdata/parser.py
@@ -71,8 +71,8 @@ class QASMToIRTransformer(Transformer):
         return self._program
 
     def statement(self, *args):
-        """A catch-all for all OpenQASM statement; this includes register, operator, and gate
-        declarations, include statements, quantum operations to be applied, and barriers.
+        """A catch-all for all OpenQASM statements; this includes register, operator, and gate
+        declarations, ``include`` statements, quantum operations to be applied, and barriers.
         """
         args = unpack(args)
 
@@ -94,7 +94,7 @@ class QASMToIRTransformer(Transformer):
             # opaque <id> <idlist>; or
             # opaque <id> () <idlist>; or
             # opaque <id> (<idlist>) <idlist>;
-            decl = self.qdecl(Declaration, *args[1:], opaque=True)
+            decl = self.qdecl(Declaration, opaque=True, *args[1:])
             stmt = decl
 
         elif isinstance(args[0], Op):

--- a/qdata/parser.py
+++ b/qdata/parser.py
@@ -61,6 +61,11 @@ class QASMToIRTransformer(Transformer):
 
         * The OpenQASM version specifier
         * The OpenQASM program
+
+        .. code-block:: text
+
+            statement
+            program statement
         """
         args = unpack(args)
 
@@ -73,6 +78,21 @@ class QASMToIRTransformer(Transformer):
     def statement(self, *args):
         """A catch-all for all OpenQASM statements; this includes register, operator, and gate
         declarations, ``include`` statements, quantum operations to be applied, and barriers.
+
+        .. code-block:: text
+
+            decl
+            gatedecl goplist "}"
+            gatedecl "}"
+            opdecl goplist "}"
+            opdecl "}"
+            OPAQUE id idlist ";"
+            OPAQUE id "(" ")" idlist ";"
+            OPAQUE id "(" idlist ")" idlist ";"
+            qop
+            IF "(" id "==" nninteger ")" qop
+            BARRIER anylist ";"
+            INCLUDE ESCAPED_STRING ";"
         """
         args = unpack(args)
 
@@ -385,13 +405,25 @@ class QASMToIRTransformer(Transformer):
         return Gate(op_name, params, wires)
 
     def anylist(self, *args):
-        """Either ``idlist`` or ``mixedlist``"""
+        """Either ``idlist`` or ``mixedlist``.
+
+        .. code-block:: text
+
+            idlist
+            mixedlist
+        """
         return ParsedList(Lists.ANYLIST, unpack(args))
 
     def idlist(self, *args):
         """Either a single id, or a list of id's. Note that
         an id is an alphanumeric label (with underscores allowed)
-        that *must* begin with a lowercase character."""
+        that *must* begin with a lowercase character.
+
+        .. code-block:: text
+
+            id
+            idlist "," id
+        """
         # <id>
         # <idlist>, <id>
         flat_list = flatten(*args)
@@ -425,11 +457,23 @@ class QASMToIRTransformer(Transformer):
         return ParsedList(Lists.MIXEDLIST, wires)
 
     def argument(self, *args):
-        """An argument is either an id, or an id with a non-negative integer index."""
+        """An argument is either an id, or an id with a non-negative integer index.
+
+        .. code-block:: text
+
+            id
+            id "[" nninteger "]"
+        """
         return unpack(args)
 
     def explist(self, *args):
-        """Either a single expression, or a comma separated list of expressions"""
+        """Either a single expression, or a comma separated list of expressions.
+
+        .. code-block:: text
+
+            exp
+            explist "," exp
+        """
         flat_list = flatten(*args)
         return ParsedList(Lists.EXPLIST, flat_list)
 

--- a/qdata/parser.py
+++ b/qdata/parser.py
@@ -1,26 +1,21 @@
 """This module contains the QASMToIRTransformer and qasm_parser"""
+# pylint: disable=too-many-public-methods
 import pathlib
-from enum import Enum
 
 import sympy
 from lark import Lark, Transformer
 
 from .ir import (
-    ArithmeticOperation,
     Barrier,
-    BinaryOperation,
-    Channel,
     ClassicalRegister,
     ConditionalOp,
     Declaration,
-    Declarations,
     EqualityCondition,
     Gate,
     GateDeclaration,
     Lists,
     Measure,
     Op,
-    Operator,
     OperatorDeclaration,
     Ops,
     ParsedList,
@@ -34,8 +29,8 @@ from .ir import (
     unpack,
 )
 
-with open(pathlib.Path(__file__).parent / "qasm.lark", "r") as f:
-    qasm_grammar = "".join(f.readlines())
+with open(pathlib.Path(__file__).parent / "qasm.lark", "r") as _f:
+    qasm_grammar = "".join(_f.readlines())
 
 qasm_parser = Lark(qasm_grammar, start="mainprogram")
 
@@ -46,6 +41,8 @@ class QASMToIRTransformer(Transformer):
     Transformers visit each node of the tree, and run the appropriate method on it according to the node's data.
     All method names mirror the corresponding symbols from the grammar.
     """
+
+    # pylint:disable=no-self-use
 
     PI = lambda self, _: sympy.pi
     sin = lambda self, _: "sin"
@@ -60,6 +57,11 @@ class QASMToIRTransformer(Transformer):
         super().__init__(self, *args, **kwargs)
 
     def mainprogram(self, *args):
+        """This is the root of the tree, and consists of two components:
+
+        * The OpenQASM version specifier
+        * The OpenQASM program
+        """
         args = unpack(args)
 
         if len(args) > 1:
@@ -69,6 +71,9 @@ class QASMToIRTransformer(Transformer):
         return self._program
 
     def statement(self, *args):
+        """A catch-all for all OpenQASM statement; this includes register, operator, and gate
+        declarations, include statements, quantum operations to be applied, and barriers.
+        """
         args = unpack(args)
 
         if isinstance(args[0], Declaration):
@@ -89,7 +94,7 @@ class QASMToIRTransformer(Transformer):
             # opaque <id> <idlist>; or
             # opaque <id> () <idlist>; or
             # opaque <id> (<idlist>) <idlist>;
-            decl = self.qdecl(Declaration, opaque=True, *args[1:])
+            decl = self.qdecl(Declaration, *args[1:], opaque=True)
             stmt = decl
 
         elif isinstance(args[0], Op):
@@ -127,6 +132,12 @@ class QASMToIRTransformer(Transformer):
         self._program.statements.append(stmt)
 
     def decl(self, *args):
+        """A quantum or classical register declaration.
+
+        .. code-block:: text
+
+            (QREG | CREG) id "[" nninteger "]" ";"
+        """
         args = unpack(args)
         reg_type = str(args[0])
         id_, size = args[1:]
@@ -134,22 +145,45 @@ class QASMToIRTransformer(Transformer):
         if reg_type == "creg":
             return ClassicalRegister(name=id_, size=size)
 
-        elif reg_type == "qreg":
+        if reg_type == "qreg":
             return QuantumRegister(name=id_, size=size)
 
         return Declaration(reg_type, id_=id_, size=size)
 
     def opdecl(self, *args):
+        """An operator declaration.
+
+        .. code-block:: text
+
+            OPERATOR id idlist "{"
+            OPERATOR id "(" ")" idlist "{"
+            OPERATOR id "(" idlist ")" idlist "{"
+        """
         args = unpack(args)
         op = self.uop([*args[1:]])
         return OperatorDeclaration(op=op)
 
     def gatedecl(self, *args):
+        """A gate declaration.
+
+        .. code-block:: text
+
+            GATE id idlist "{"
+            GATE id "(" ")" idlist "{"
+            GATE id "(" idlist ")" idlist "{"
+        """
         args = unpack(args)
         op = self.uop([*args[1:]])
         return GateDeclaration(op=op)
 
-    def qdecl(self, cls, *args):
+    @staticmethod
+    def qdecl(decl_cls, *args, **kwargs):
+        """A utility static method for easily constructing and returning
+        the correct ``Declaration`` class.
+        """
+        # TODO: this seems to only be called from a single location; the OPAQUE
+        # branch within the statement. opdecl and gatedecl do not call this
+        # method. It is probably worth removing this separate method.
         args = unpack(args)
         decl_type = str(args[0])
         id_ = args[1]
@@ -164,10 +198,24 @@ class QASMToIRTransformer(Transformer):
             param_ids = None
 
         register_ids = flatten(args[-1])
-        kwargs = {"inputs": param_ids, "wires": register_ids}
-        return cls(decl_type, name=id_, **kwargs)
+        kwargs = {"inputs": param_ids, "wires": register_ids, **kwargs}
+        return decl_cls(decl_type, name=id_, **kwargs)
 
     def goplist(self, *args):
+        """A node containing a list of gate operations. The list of
+        gate operations can either be a single unitary operation,
+        an operator term, or a barrier. Alternatively, it can be a combination
+        of the above.
+
+        .. code-block:: text
+
+            uop
+            term
+            BARRIER idlist ";"
+            goplist uop
+            goplist term
+            goplist BARRIER idlist ";"
+        """
         args = unpack(args)
 
         if len(args) == 1:
@@ -192,7 +240,19 @@ class QASMToIRTransformer(Transformer):
             # <goplist> <term>
             return ParsedList(Lists.GOPLIST, flatten(args))
 
+        # TODO: Add proper parser validation and exceptions, including returning
+        # to the user the source code line number that causes the exception.
+        # The Lark documentation should have details regarding this.
+        raise ValueError(f"Invalid GOPLIST arguments: {args}")
+
     def term(self, *args):
+        """A single term of an operator.
+
+        .. code-block:: text
+
+            exp uop
+            "-" uop
+        """
         # <term>
         args = unpack(args)
 
@@ -208,6 +268,15 @@ class QASMToIRTransformer(Transformer):
         return flatten(t)
 
     def qop(self, *args):
+        """A quantum operation. This consists of either a unitary operation (uop),
+        measurement, or wire reset.
+
+        .. code-block:: text
+
+            uop
+            MEASURE argument "->" argument ";"
+            RESET argument ";"
+        """
         args = unpack(args)
 
         if len(args) == 1:
@@ -217,13 +286,42 @@ class QASMToIRTransformer(Transformer):
         if args[0] == "reset":
             # reset <argument>;
             wires = args[1].list
-        elif args[0] == "measure":
+            return Op(Ops.RESET, name=args[0], params=[], wires=wires)
+
+        if args[0] == "measure":
             wires = args[1:]
             return Measure(wires=wires)
 
-        return Op(name=args[0], params=[], wires=wires)
+        # TODO: Check the operator kind this 'catch-all' return
+        # actually refers to. Perhaps this return statement isn't even covered?
+        return Op(Ops.GATE, name=args[0], params=[], wires=wires)
 
     def uop(self, *args):
+        """A unitary operation.
+
+        This can consist of:
+
+        * Intrinsic quantum operations (U, CX)
+        * Declared quantum operations
+        * A tensor product of operators acting on different wires (specified via comma separated values)
+
+        Unitary operations can have parameters, and can be applied
+        to either single wires, or a list of wires.
+
+        .. code-block:: text
+
+            U "(" explist ")" argument ";"
+            CX argument "," argument ";"
+            id anylist ";"
+            id "(" ")" anylist ";"
+            id "(" explist ")" anylist ";"
+            id anylist "," uop
+            id "(" ")" anylist "," uop
+            id "(" explist ")" anylist "," uop
+        """
+
+        # TODO: should we add support for more primitives/intrinsic gates? OpenQASM 2.0 will likely
+        # be updated soon to replace CX, U with CX, P, SX as the intrinsic gate set.
         args = unpack(args)
         op_name = str(args[0])
         other_op = None
@@ -287,16 +385,32 @@ class QASMToIRTransformer(Transformer):
         return Gate(op_name, params, wires)
 
     def anylist(self, *args):
-        # either <idlist> or <mixedlist>
+        """Either ``idlist`` or ``mixedlist``"""
         return ParsedList(Lists.ANYLIST, unpack(args))
 
     def idlist(self, *args):
+        """Either a single id, or a list of id's. Note that
+        an id is an alphanumeric label (with underscores allowed)
+        that *must* begin with a lowercase character."""
         # <id>
         # <idlist>, <id>
         flat_list = flatten(*args)
         return ParsedList(Lists.IDLIST, flat_list)
 
     def mixedlist(self, *args):
+        """A mixed list is a list that includes a combination
+        (of comma separated) id's, and id's with a non-negative integer index (specified
+        via square brackets).
+
+        .. code-block:: text
+
+            id "[" nninteger "]"
+            mixedlist "," id
+            mixedlist "," id "[" nninteger "]"
+            idlist "," id "[" nninteger "]"
+        """
+        # TODO: This definition doesn't really make sense. The mixedlist
+        # definition could be re-written using `argument`.
         args = unpack(args)
         if isinstance(args[0], ParsedList):
             # <mixedlist>, <id> or
@@ -311,57 +425,107 @@ class QASMToIRTransformer(Transformer):
         return ParsedList(Lists.MIXEDLIST, wires)
 
     def argument(self, *args):
-        # <id> or
-        # <id>[<nninteger>]
+        """An argument is either an id, or an id with a non-negative integer index.
+        """
         return unpack(args)
 
     def explist(self, *args):
+        """Either a single expression, or a comma separated list of expressions"""
         flat_list = flatten(*args)
         return ParsedList(Lists.EXPLIST, flat_list)
 
     def exp(self, *args):
+        """A mathematica expression.
+
+        This includes:
+
+        * A real value
+        * A non-negative integer
+        * Mathematical constants (currently just pi)
+        * A symbolic parameter (simply id, so must always start with a lowercase character)
+        * Parenthesis
+        * Unary arithmetic operators (-, unaryop)
+        * Binary arithmetic operators (+, -, *, /, ^)
+
+        .. code-block:: text
+
+            real
+            nninteger
+            PI
+            id -> parameter
+            exp "+" exp -> add
+            exp "-" exp -> subtract
+            exp "*" exp -> multiply
+            exp "/" exp -> divide
+            "-" exp -> negate
+            exp "^" exp -> binary_exp
+            "(" exp ")"
+            unaryop "(" exp ")"
+        """
+        # TODO: Check what happens if a negative integer is specified. This will likely
+        # result in a float being returned, which is not ideal (larger memory requirements,
+        # plus the potential for propagation of precision error).
+
+        # TODO: support parameters that start with a capital letter?
+
         args = unpack(args)
+
         if len(args) == 1:
             # numbers, ids, or resolved exps, just need to flatten
             return unpack(args)
-        elif len(args) == 2:
+
+        if len(args) == 2:
             # unary ops
             func, x = args
             return UnaryOperation(func, x)
 
+        # TODO: Have proper validation here
+        raise ValueError
+
     def add(self, exp):
+        """Binary addition"""
         (lterm, rterm) = exp
         return lterm + rterm
 
     def subtract(self, exp):
+        """Binary subtraction"""
         (lterm, rterm) = exp
         return lterm - rterm
 
     def multiply(self, exp):
+        """Binary multiplication"""
         (lterm, rterm) = exp
         return lterm * rterm
 
     def divide(self, exp):
+        """Binary floating-point division"""
         (lterm, rterm) = exp
         return lterm / rterm
 
     def binary_exp(self, exp):
+        """Binary exponentiation"""
         (base, exponent) = exp
         return base ** exponent
 
     def negate(self, exp):
+        """Unary negation"""
         (val,) = exp
         return -val
 
     def id_(self, name):
+        """Returns the Python string corresponding to the id"""
         name = unpack(name)
         return name.value
 
     def real(self, args):
+        """Returns a Python float corresponding to a real"""
         return float(unpack(args))
 
     def nninteger(self, n):
+        """Returns a Python integer corresponding to a non-negative integer"""
         return int(unpack(n))
 
     def parameter(self, name):
+        """Returns a sympy symbol representing a symbolic parameter used
+        within an expression"""
         return sympy.Symbol(name[0])

--- a/qdata/parser.py
+++ b/qdata/parser.py
@@ -187,7 +187,7 @@ class QASMToIRTransformer(Transformer):
         args = unpack(args)
         decl_type = str(args[0])
         id_ = args[1]
-        idlist1 = flatten(args[2])
+        # idlist1 = flatten(args[2]) (this variable does not seem to be used?)
 
         if len(args) == 4:
             # decl_type <id> ( <idlist> ) <idlist> {

--- a/qdata/parser.py
+++ b/qdata/parser.py
@@ -425,8 +425,7 @@ class QASMToIRTransformer(Transformer):
         return ParsedList(Lists.MIXEDLIST, wires)
 
     def argument(self, *args):
-        """An argument is either an id, or an id with a non-negative integer index.
-        """
+        """An argument is either an id, or an id with a non-negative integer index."""
         return unpack(args)
 
     def explist(self, *args):


### PR DESCRIPTION
**Context:** Before writing a test suite, it makes sense to first perform static analysis of the code, in order to catch any obvious bugs and deficiencies. This ensures that we begin writing functional tests from a higher level of quality. It also will allow us to better keep track of TODOs present in the source code.

**Description of changes:**

* A `.pylintrc` config file is added to ensure some sensible defaults.

* The `qdata/` folder was linted, and any reported bugs fixed. This includes:

  - The `insert_includes` keyword argument was not correctly serializing the included files when set to `True`. This has been fixed; in addition, it was renamed to `inline`. This is inspired from C, where `inline` instructs the compiler to 'inline' any header definitions. Here, we use the term to instruct the serializer to 'inline' any included files.

  - The OpenQASM version was being set to `2.0` by default, _even if not specified in the parsed file_. This does not make sense; the IR should reflect the parsed file exactly. The default has been changed to `None`.

  - The `Ops.RESET` enum has been added to the IR, and used within the parser.

  - Redundant `super()` calls were removed.

  - Docstrings were added where missing.

  - Unused imports were removed.

  - In some cases, keyword arguments were being used incorrectly (e.g., kwargs before args, kwargs not being defined). This has been corrected.

* Finally, while linting, future tasks/issues were noted via `TODO` comments.

**Benefits:**

* Code is now slightly cleaner, which should help with new developer onboarding.

* Minimal docstrings have been added, which should help with development/keeping track of relationships between methods.

* Various bugs have been fixed.

* It is now easier to keep track of TODOs, via pylint:

  ```console
  $ pylint qdata
  ************* Module qdata.ir
  qdata/ir.py:351:2: W0511: TODO: improve this so tensor products print like "x a, y b;" (fixme)
  ************* Module qdata.parser
  qdata/parser.py:184:2: W0511: TODO: this seems to only be called from a single location; the OPAQUE (fixme)
  qdata/parser.py:243:2: W0511: TODO: Add proper parser validation and exceptions, including returning (fixme)
  qdata/parser.py:263:2: W0511: TODO: check that this still holds (fixme)
  qdata/parser.py:295:2: W0511: TODO: Check the operator kind this 'catch-all' return (fixme)
  qdata/parser.py:323:2: W0511: TODO: should we add support for more primitives/intrinsic gates? OpenQASM 2.0 will likely (fixme)
  qdata/parser.py:366:2: W0511: TODO: consider extending the grammar so users can specify (fixme)
  qdata/parser.py:372:2: W0511: TODO: this case should not occur, according (fixme)
  qdata/parser.py:412:2: W0511: TODO: This definition doesn't really make sense. The mixedlist (fixme)
  qdata/parser.py:465:2: W0511: TODO: Check what happens if a negative integer is specified. This will likely (fixme)
  qdata/parser.py:469:2: W0511: TODO: support parameters that start with a capital letter? (fixme)
  qdata/parser.py:482:2: W0511: TODO: Have proper validation here (fixme)
  qdata/parser.py:190:8: W0612: Unused variable 'idlist1' (unused-variable)
  
  ------------------------------------------------------------------
  Your code has been rated at 9.72/10 (previous run:  7.81/10, +1.91)
  ```

**Next steps:**

* Write tests