### PR TITLE
Update representations

### DIFF
--- a/qdata/ir.py
+++ b/qdata/ir.py
@@ -234,7 +234,7 @@ class Op:
         return f"{self.name} {','.join(str(w) for w in self.wires)};"
 
     def __repr__(self):
-        kind = self.kind.name.title() if not self.kind.name=="OPERATOR" else "Quantum"
+        kind = self.kind.name.title() if not self.kind.name == "OPERATOR" else "Quantum"
         return f"<{kind}Operation: name={self.name}, wires={self.wires}>"
 
 
@@ -316,6 +316,7 @@ class Measure(Op):
         wires = [format_wires(w) for w in self.wires]
         return f"<MeasureOperation: wires={wires}>"
 
+
 class Barrier(Op):
     """Class for representing the 'barrier' keyword."""
 
@@ -325,6 +326,7 @@ class Barrier(Op):
     def __repr__(self):
         wires = [format_wires(w) for w in self.wires]
         return f"<BarrierOperation: wires={wires}>"
+
 
 class EqualityCondition:
     """Class for representing the classical equality expression from the specification.
@@ -340,7 +342,7 @@ class EqualityCondition:
         return f"{self.id} == {self.integer}"
 
     def __repr__(self):
-        return f'<EqualityCondition: {self.id}=={self.integer}>'
+        return f"<EqualityCondition: {self.id}=={self.integer}>"
 
 
 class ConditionalOp:
@@ -356,7 +358,7 @@ class ConditionalOp:
         return f"if ({self.condition}) {self.op}"
 
     def __repr__(self):
-        return f'<ConditionalOperation: {self.condition}, op={self.op.name}, wires={self.op.wires}>'
+        return f"<ConditionalOperation: {self.condition}, op={self.op.name}, wires={self.op.wires}>"
 
 
 class Declaration:
@@ -454,4 +456,6 @@ class OperatorDeclaration(Declaration):
         return f"operator {self.kwargs['op']}"[:-1]
 
     def __repr__(self):
-        return f"<OperatorDeclaration: name={self.kwargs['op'].name}, wires={self.kwargs['op'].wires}>"
+        return (
+            f"<OperatorDeclaration: name={self.kwargs['op'].name}, wires={self.kwargs['op'].wires}>"
+        )

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -1,0 +1,46 @@
+"""Test representations of ir functions"""
+import pytest
+from qdata import ir
+
+# example arguments
+list_ = [1, 2, 3]
+name = "my_name"
+func = "my_func"
+kind = ir.Ops.OPERATOR
+params = ["alpha", "beta"]
+wires_formatted = ['q[0]', 'c[1]']
+wires = [["q", 0], ["c", 1]]
+args = 1, 2, 3, 4
+op = ir.Op(kind, name, params, wires_formatted)
+ops = [op, op]
+coeff = 1.
+id_ = 123
+integer = 42
+condition = "c==1"
+decl_type = ir.Declarations.GATE
+size = 10
+
+@pytest.mark.parametrize("ir_func, ir_params, expected", [
+    (ir.ParsedList, [name, list_], f"<ParsedList: name={name}, size={len(list_)}>"),
+    (ir.ArithmeticOperation, [func, *args], f"<ArithmeticOperation: func={func}>"),
+    (ir.UnaryOperation, [func, *args], f"<UnaryOperation: func={func}>"),
+    (ir.BinaryOperation, [func, *args], f"<BinaryOperation: op={func}>"),
+    (ir.Op, [kind, name, params, wires_formatted], f"<QuantumOperation: name={name}, wires={wires_formatted}>"),
+    (ir.Gate, [name, params, wires_formatted], f"<GateOperation: name={name}, wires={wires_formatted}>"),
+    (ir.Channel, [name, params, wires_formatted], f"<ChannelOperation: name={name}, wires={wires_formatted}>"),
+    (ir.Operator, [name, params, wires_formatted], f"<QuantumOperation: name={name}, wires={wires_formatted}>"),
+    (ir.TensorOp, [*ops], f"<TensorOperation: ops=['{name}', '{name}'], wires={wires_formatted * len(ops)}>"),
+    (ir.Term, [coeff, op], f"<Term: coeff={coeff}, op={name}, wires={wires_formatted}>"),
+    (ir.Measure, [wires], f"<MeasureOperation: wires={wires_formatted}>"),
+    (ir.Barrier, [wires], f"<BarrierOperation: wires={wires_formatted}>"),
+    (ir.EqualityCondition, [id_, integer], f"<EqualityCondition: {id_}=={integer}>"),
+    (ir.ConditionalOp, [condition, op], f"<ConditionalOperation: {condition}, op={name}, wires={wires_formatted}>"),
+    (ir.Declaration, [decl_type, False], f"<Declaration: name={decl_type.name.lower()}>"),
+    (ir.ClassicalRegister, [name, size], f"<ClassicalRegister: size={size}>"),
+    (ir.QuantumRegister, [name, size], f"<QuantumRegister: size={size}>"),
+    (ir.GateDeclaration, [op], f"<GateDeclaration: name={name}, wires={wires_formatted}>"),
+    (ir.OperatorDeclaration, [op], f"<OperatorDeclaration: name={name}, wires={wires_formatted}>"),
+])
+def test_repr(ir_func, ir_params, expected):
+    """Test that the representation of each function is correctly returned"""
+    assert ir_func(*ir_params).__repr__() == expected


### PR DESCRIPTION
**Context:**
As stated in #20 the `__repr__()` methods are currently used for serialization. This is not ideal, since we don't really want serialization to happen each time `__repr__()` is called. Instead that method should return a brief representation of the object.

**Description of the Change:**
* All current `__repr__()` methods are renamed `__str__()` so that the serialization is done by calling `str()` instead. This was mentioned as a potential solution in the linked issue.
* Each function now has a new `__repr__()` method that, when called, returns a nice representation of the object.

**Benefits:**
`__repr__()` works as expected.

**Possible Drawbacks:**
Whether the `__str__()` solution is the _best_ solution is still up for discussion. Another suggestion would be to create a `serialize()` method (see #20 for further details) 

**Related GitHub Issues:**
#20 
